### PR TITLE
Update how-to-run-container.md

### DIFF
--- a/data-api-builder/how-to-run-container.md
+++ b/data-api-builder/how-to-run-container.md
@@ -109,6 +109,14 @@ Create a configuration file that maps to the table created in the previous steps
         "database-type": "mssql",
         "connection-string": "Server=host.docker.internal\\mssql,1433;Initial Catalog=Library;User Id=sa;Password=<your-password>;TrustServerCertificate=true;"
       },
+      "runtime": {
+        "rest": {
+          "enabled": true
+        },
+        "graphql": {
+          "enabled": true
+        }
+      },
       "entities": {
         "book": {
           "source": "dbo.Books",


### PR DESCRIPTION
Configuration includes additional runtime settings for REST and GraphQL. Without this DAB didn't want to start.