### PR TITLE
DAB Docs changes for `dab configure [options] [value]` command to update RuntimeConfig sections

### DIFF
--- a/data-api-builder/reference-command-line-interface.md
+++ b/data-api-builder/reference-command-line-interface.md
@@ -221,6 +221,52 @@ dab validate
 | --- | --- | --- | --- | --- | --- |
 | **-c,--config** | ❌ No | `dab-config.json` | ✔️ Yes | string | Path to the config file that is the target of validation. |
 
+### `configure`
+
+The `dab configure` command is designed to simplify updating config properties outside of the entities section. This document outlines the design, functionality, and implementation details of the dab configure command. It supports to edit the CLI for configuration properties in data-source and runtime sections of the runtime config.
+
+> [!NOTE]
+> `dab configure` is only for updating the data-source and runtime sections of the config. For the entities section, we already have the dab update command.
+
+#### Syntax
+
+```dotnetcli
+dab configure [options] [value]
+```
+
+#### Examples
+
+```dotnetcli
+dab configure --runtime.rest.enabled true
+```
+
+#### Options
+
+| Configuration File Property Path                                        | CLI Flag                                                           | Data Type | Nullable |
+|-------------------------------------------------------------------------|--------------------------------------------------------------------|-----------|----------|
+| data-source.<br/>database-type                                          | <nobr>--data-source.database-type</nobr>                           | String: `MSSQL`, `PostgreSQL`, `CosmosDB`, `MySQL` | ❌ |
+| data-source.<br/>connection-string                                      | <nobr>--data-source.connection-string</nobr>                       | String    | ❌       |
+| data-source.<br/>options.database                                       | <nobr>--data-source.options.database</nobr>                        | String    | ✅       |
+| data-source.<br/>options.container                                      | <nobr>--data-source.options.container</nobr>                       | String    | ✅       |
+| data-source.<br/>options.schema                                         | <nobr>--data-source.options.schema</nobr>                          | String    | ✅       |
+| data-source.<br/>options.set-session-context                            | <nobr>--data-source.options.set-session-context</nobr>             | Boolean: `true`, `false` (default: `false`) | ✅ |
+| data-source-files                                                       | <nobr>--data-source-files</nobr>                                   | Array of strings | ✅ |
+| runtime.<br/>rest.path                                                  | <nobr>--runtime.rest.path</nobr>                                   | String (default: `/api`) | ❌       |
+| runtime.<br/>rest.enabled                                               | <nobr>--runtime.rest.enabled</nobr>                                | Boolean: `true`, `false` (default: `true`) | ❌ |
+| runtime.<br/>rest.request-body-strict                                   | <nobr>--runtime.rest.request-body-strict</nobr>                    | Boolean: `true`, `false` (default: `true`) | ✅ |
+| runtime.<br/>graphql.allow-introspection                                | <nobr>--runtime.graphql.allow-introspection</nobr>                 | Boolean: `true`, `false` (default: `true`) | ✅ |
+| runtime.<br/>graphql.path                                               | <nobr>--runtime.graphql.path</nobr>                                | String (default: `/graphql`) | ❌       |
+| runtime.<br/>graphql.enabled                                            | <nobr>--runtime.graphql.enabled</nobr>                             | Boolean: `true`, `false` (default: `true`) | ❌ |
+| runtime.<br/>graphql.multiple-mutations.create.enabled                  | <nobr>--runtime.graphql.multiple-mutations.create.enabled</nobr>   | Boolean: `true`, `false` (default: `true`) | ✅ |
+| runtime.<br/>host.mode                                                  | <nobr>--runtime.host.mode</nobr>                                   | String: `Development`, `Production` | ❌ |
+| runtime.<br/>host.cors.origins                                          | <nobr>--runtime.host.cors.origins</nobr>                           | Array of strings | ✅ |
+| runtime.<br/>host.cors.allow-credentials                                | <nobr>--runtime.host.cors.allow-credentials</nobr>                 | Boolean: `true`, `false` (default: `false`) | ✅ |
+| runtime.<br/>host.authentication.provider                               | <nobr>--runtime.host.authentication.provider</nobr>                | String: `StaticWebApps`, `AppService`, `AzureAD`, `Jwt` | ✅ |
+| runtime.<br/>host.authentication.jwt.audience                           | <nobr>--runtime.host.authentication.jwt.audience</nobr>            | Array of strings | ✅ |
+| runtime.<br/>host.authentication.jwt.issuer                             | <nobr>--runtime.host.authentication.jwt.issuer</nobr>              | String    | ✅       |
+| runtime.<br/>cache.enabled                                              | <nobr>--runtime.cache.enabled</nobr>                               | Boolean: `true`, `false` (default: `false`) | ✅ |
+| runtime.<br/>cache.ttl-seconds                                          | <nobr>--runtime.cache.ttl-seconds</nobr>                           | Integer (default: `3600`) | ✅       |
+
 ## Related content
 
 - [Functions reference](reference-functions.md)

--- a/data-api-builder/reference-command-line-interface.md
+++ b/data-api-builder/reference-command-line-interface.md
@@ -242,30 +242,30 @@ dab configure --runtime.rest.enabled true
 
 #### Options
 
-| Configuration File Property Path                                        | CLI Flag                                                           | Data Type | Nullable |
-|-------------------------------------------------------------------------|--------------------------------------------------------------------|-----------|----------|
-| data-source.<br/>database-type                                          | <nobr>--data-source.database-type</nobr>                           | String: `MSSQL`, `PostgreSQL`, `CosmosDB`, `MySQL` | ❌ |
-| data-source.<br/>connection-string                                      | <nobr>--data-source.connection-string</nobr>                       | String    | ❌       |
-| data-source.<br/>options.database                                       | <nobr>--data-source.options.database</nobr>                        | String    | ✅       |
-| data-source.<br/>options.container                                      | <nobr>--data-source.options.container</nobr>                       | String    | ✅       |
-| data-source.<br/>options.schema                                         | <nobr>--data-source.options.schema</nobr>                          | String    | ✅       |
-| data-source.<br/>options.set-session-context                            | <nobr>--data-source.options.set-session-context</nobr>             | Boolean: `true`, `false` (default: `false`) | ✅ |
-| data-source-files                                                       | <nobr>--data-source-files</nobr>                                   | Array of strings | ✅ |
-| runtime.<br/>rest.path                                                  | <nobr>--runtime.rest.path</nobr>                                   | String (default: `/api`) | ❌       |
-| runtime.<br/>rest.enabled                                               | <nobr>--runtime.rest.enabled</nobr>                                | Boolean: `true`, `false` (default: `true`) | ❌ |
-| runtime.<br/>rest.request-body-strict                                   | <nobr>--runtime.rest.request-body-strict</nobr>                    | Boolean: `true`, `false` (default: `true`) | ✅ |
-| runtime.<br/>graphql.allow-introspection                                | <nobr>--runtime.graphql.allow-introspection</nobr>                 | Boolean: `true`, `false` (default: `true`) | ✅ |
-| runtime.<br/>graphql.path                                               | <nobr>--runtime.graphql.path</nobr>                                | String (default: `/graphql`) | ❌       |
-| runtime.<br/>graphql.enabled                                            | <nobr>--runtime.graphql.enabled</nobr>                             | Boolean: `true`, `false` (default: `true`) | ❌ |
-| runtime.<br/>graphql.multiple-mutations.create.enabled                  | <nobr>--runtime.graphql.multiple-mutations.create.enabled</nobr>   | Boolean: `true`, `false` (default: `true`) | ✅ |
-| runtime.<br/>host.mode                                                  | <nobr>--runtime.host.mode</nobr>                                   | String: `Development`, `Production` | ❌ |
-| runtime.<br/>host.cors.origins                                          | <nobr>--runtime.host.cors.origins</nobr>                           | Array of strings | ✅ |
-| runtime.<br/>host.cors.allow-credentials                                | <nobr>--runtime.host.cors.allow-credentials</nobr>                 | Boolean: `true`, `false` (default: `false`) | ✅ |
-| runtime.<br/>host.authentication.provider                               | <nobr>--runtime.host.authentication.provider</nobr>                | String: `StaticWebApps`, `AppService`, `AzureAD`, `Jwt` | ✅ |
-| runtime.<br/>host.authentication.jwt.audience                           | <nobr>--runtime.host.authentication.jwt.audience</nobr>            | Array of strings | ✅ |
-| runtime.<br/>host.authentication.jwt.issuer                             | <nobr>--runtime.host.authentication.jwt.issuer</nobr>              | String    | ✅       |
-| runtime.<br/>cache.enabled                                              | <nobr>--runtime.cache.enabled</nobr>                               | Boolean: `true`, `false` (default: `false`) | ✅ |
-| runtime.<br/>cache.ttl-seconds                                          | <nobr>--runtime.cache.ttl-seconds</nobr>                           | Integer (default: `3600`) | ✅       |
+| Configuration File Property | CLI Flag | Data Type | Nullable | Description |
+|-----------------------|-------------------------------------------|-----------|----------|----------------------------------------------------|
+| data-source.<br/>database-type                                          | <nobr>--data-source.database-type</nobr>                           | String: `MSSQL`, `PostgreSQL`, `CosmosDB_NoSQL`, `MySQL` | ❌ | This value indicates the Database type. |
+| data-source.<br/>connection-string                                      | <nobr>--data-source.connection-string</nobr>                       | String    | ❌       | Refers to the connection string for the data source. |
+| data-source.<br/>options.database                                       | <nobr>--data-source.options.database</nobr>                        | String    | ✅       | Refers to the database name for Cosmos DB for NoSql. |
+| data-source.<br/>options.container                                      | <nobr>--data-source.options.container</nobr>                       | String    | ✅       | Refers to the Container name for Cosmos DB for NoSql. |
+| data-source.<br/>options.schema                                         | <nobr>--data-source.options.schema</nobr>                          | String    | ✅       | Provides the Schema path for Cosmos DB for NoSql. |
+| data-source.<br/>options.set-session-context                            | <nobr>--data-source.options.set-session-context</nobr>             | Boolean: `true`, `false` (default: `true`) | ✅ | Whether to Enable session context. |
+| runtime.<br/>rest.enabled                                               | <nobr>--runtime.rest.enabled</nobr>                                | Boolean: `true`, `false` (default: `true`) | ❌ | Signifies whether to Enable DAB's REST endpoint. |
+| runtime.<br/>rest.path                                                  | <nobr>--runtime.rest.path</nobr>                                   | String (default: `/api`) | ❌       | Customize DAB's REST endpoint path. Conditions: Prefix with '/', no spaces and no reserved characters. |
+| runtime.<br/>rest.request-body-strict                                   | <nobr>--runtime.rest.request-body-strict</nobr>                    | Boolean: `true`, `false` (default: `true`) | ✅ | Allows/Prohibits extraneous REST request body fields. |
+| runtime.<br/>graphql.enabled                                            | <nobr>--runtime.graphql.enabled</nobr>                             | Boolean: `true`, `false` (default: `true`) | ❌ | Enable/Disable DAB's GraphQL endpoint. 
+| runtime.<br/>graphql.path                                               | <nobr>--runtime.graphql.path</nobr>                                | String (default: `/graphql`) | ❌       | Customize DAB's GraphQL endpoint path. Conditions: Prefix with '/', no spaces and no reserved characters. |
+| runtime.<br/>graphql.depth-limit                                                       | <nobr>--runtime.graphql.depth-limit</nobr>                                   | Integer | ✅ | This refers to the Max allowed depth of the graphQL nested query. Allowed values: (0,2147483647] inclusive. Default is infinity. Use -1 to remove limit. |
+| runtime.<br/>graphql.allow-introspection                                | <nobr>--runtime.graphql.allow-introspection</nobr>                 | Boolean: `true`, `false` (default: `true`) | ✅ | Allow/Deny GraphQL introspection requests in GraphQL Schema. |
+| runtime.<br/>graphql.multiple-mutations.create.enabled                  | <nobr>--runtime.graphql.multiple-mutations.create.enabled</nobr>   | Boolean: `true`, `false` (default: `true`) | ✅ | Enable/Disable multiple-mutation create operations on DAB's generated GraphQL schema. |
+| runtime.<br/>host.mode                                                  | <nobr>--runtime.host.mode</nobr>                                   | String: `Development`, `Production` Default: `Development` | ❌ | Set the host running mode of DAB in Development or Production. |
+| runtime.<br/>host.cors.origins                                          | <nobr>--runtime.host.cors.origins</nobr>                           | Array of strings | ✅ | Use this to Overwrite Allowed Origins in CORS. Default: [] (Space separated array of strings). |
+| runtime.<br/>host.cors.allow-credentials                                | <nobr>--runtime.host.cors.allow-credentials</nobr>                 | Boolean: `true`, `false` (default: `false`) | ✅ | Set value for Access-Control Allow-Credentials header in --host.cors.allow-credentials . |
+| runtime.<br/>host.authentication.provider                               | <nobr>--runtime.host.authentication.provider</nobr>                | String: `StaticWebApps`, `AppService`, `AzureAD`, `Jwt` | ✅ | Configure the name of authentication provider. Default: `StaticWebApps`. |
+| runtime.<br/>host.authentication.jwt.audience                           | <nobr>--runtime.host.authentication.jwt.audience</nobr>            | Array of strings | ✅ | Use this to Configure the intended recipient(s) of the Jwt Token. |
+| runtime.<br/>host.authentication.jwt.issuer                             | <nobr>--runtime.host.authentication.jwt.issuer</nobr>              | String    | ✅       | This refers to the entity that issued the Jwt Token. |
+| runtime.<br/>cache.enabled                                              | <nobr>--runtime.cache.enabled</nobr>                               | Boolean: `true`, `false` (default: `false`) | ✅ | Enable/Disable DAB's cache globally. (You must also enable each entity's cache separately.). |
+| runtime.<br/>cache.ttl-seconds                                          | <nobr>--runtime.cache.ttl-seconds</nobr>                           | Integer (default: `5`) | ✅       | Customize the DAB cache's global default time to live in seconds. |
 
 ## Related content
 


### PR DESCRIPTION
These changes are with respect to the new command that has been added in DAB
`dab configure [options] [value]`
These changes include modifications made for Datasource and Runtime sections of the config. 
This command is newly added to modify the config for sections other than entities as we already have a `dab update` command for that. 