### PR TITLE
Update reference-configuration.md

### DIFF
--- a/data-api-builder/reference-configuration.md
+++ b/data-api-builder/reference-configuration.md
@@ -2610,7 +2610,7 @@ WHERE Id = @userId;
         "object": "dbo.GetUser",
         "type": "stored-procedure",
         "parameters": {
-          "userId": "number"
+          "userId": 1234
         }
       }
     }


### PR DESCRIPTION
Update example stored procedure with parameters - INT parameter should be defined with a sample INT such as 1234 instead of literal string "number."  See following discussion for details.

https://github.com/Azure/data-api-builder/discussions/2608