### PR TITLE
Fix book mapping example

### DIFF
--- a/data-api-builder/reference-configuration.md
+++ b/data-api-builder/reference-configuration.md
@@ -3921,9 +3921,9 @@ Here's another example of mappings.
     "Book": {
       ...
       "mappings": {
-        "id": "BookID",
-        "title": "BookTitle",
-        "author": "AuthorName"
+        "BookID": "id",
+        "BookTitle": "title",
+        "AuthorName": "author"
       }
     }
   }


### PR DESCRIPTION
The key should be the database fieldname, the value should be your desired name. As written under the example, the `BookID`, `BookTitle`, `AuthorName` values are database fieldnames.