### PR TITLE
Add Hosted MCP in Connector Namespace as a deployment option

### DIFF
--- a/data-api-builder/TOC.yml
+++ b/data-api-builder/TOC.yml
@@ -293,6 +293,9 @@
     - name: Azure Kubernetes Service
       href: deployment/azure-kubernetes-service.md
       displayName: azure, aks, kubernetes, publish, deploy
+    - name: Hosted MCP
+      href: /azure/logic-apps/connector-namespace/hosted-mcp-quickstart?pivots=sql
+      displayName: azure, logic apps, connector namespace, hosted mcp, publish, deploy
     - name: Run locally (container)
       href: deployment/local-container.md
       displayName: docker, container, dab, run

--- a/data-api-builder/deployment/index.yml
+++ b/data-api-builder/deployment/index.yml
@@ -92,6 +92,19 @@ landingContent:
           - text: Deployment best practices
             url: ../concept/security/best-practices.md
 
+  - title: Hosted MCP in Connector Namespace
+    linkLists:
+      - linkListType: how-to-guide
+        links:
+          - text: "Quickstart: Create a hosted MCP server in a connector namespace"
+            url: /azure/logic-apps/connector-namespace/hosted-mcp-quickstart?pivots=sql
+      - linkListType: reference
+        links:
+          - text: Azure Connector Namespace overview
+            url: /azure/logic-apps/connector-namespace/connector-namespace-overview
+          - text: Hosted MCP servers
+            url: /azure/logic-apps/connector-namespace/connector-namespace-hosted-mcp
+
   - title: Local Docker container
     linkLists:
       - linkListType: how-to-guide


### PR DESCRIPTION
## Summary

Adds **Hosted MCP** (Connector Namespace) as another deployment option for Data API builder.

### Changes
- **TOC.yml**: New `Hosted MCP` entry in the Deployment section, placed right after **Azure Kubernetes Service**. The `href` points to the hosted MCP quickstart (SQL pivot) in the azure-docs repo. Because the quickstart lives in a different docset/repo, it uses a [site-relative cross-repo link](https://learn.microsoft.com/help/platform/navigation-set-up-contextual-toc) (locale omitted) with the pivot query string:
  ```yaml
  - name: Hosted MCP
    href: /azure/logic-apps/connector-namespace/hosted-mcp-quickstart?pivots=sql
  ```
- **deployment/index.yml**: New landing-page section **Hosted MCP in Connector Namespace** with:
  - how-to-guide → hosted MCP quickstart (SQL pivot)
  - references → [Azure Connector Namespace overview](https://learn.microsoft.com/azure/logic-apps/connector-namespace/connector-namespace-overview) and [Hosted MCP servers](https://learn.microsoft.com/azure/logic-apps/connector-namespace/connector-namespace-hosted-mcp)

Cross-repo target: https://learn.microsoft.com/azure/logic-apps/connector-namespace/hosted-mcp-quickstart?pivots=sql