### PR TITLE
Updating AppService authentication warning

### DIFF
--- a/data-api-builder/concept/security/authenticate-easy-auth.md
+++ b/data-api-builder/concept/security/authenticate-easy-auth.md
@@ -3,10 +3,10 @@ title: Configure App Service authentication (EasyAuth)
 description: Learn how to configure Data API builder with Azure App Service authentication, including local testing with the X-MS-CLIENT-PRINCIPAL header.
 author: jerrynixon
 ms.author: jnixon
-ms.reviewer: jerrynixon
+ms.reviewer: roblescarlos
 ms.service: data-api-builder
 ms.topic: how-to
-ms.date: 05/14/2026
+ms.date: 07/06/2026
 ---
 
 # Configure App Service authentication (EasyAuth)
@@ -17,7 +17,7 @@ Azure App Service provides built-in authentication (often called "EasyAuth") tha
 > The `AppService` provider trusts identity headers forwarded by EasyAuth. Ensure clients can't bypass EasyAuth and reach Data API builder directly.
 
 > [!WARNING]
-> Use the `AppService` authentication provider only when hosting in Azure App Service or Azure Functions on App Service. Setting this provider on a bare Windows host or non-App Service environment causes startup failures because the required EasyAuth infrastructure is absent. For local testing, simulate EasyAuth by sending the `X-MS-CLIENT-PRINCIPAL` header manually. See [Test locally with X-MS-CLIENT-PRINCIPAL](#step-4-test-locally-with-x-ms-client-principal).
+> Use the `AppService` authentication provider only when hosting in Azure App Service or Azure Functions on App Service since it trusts the X-MS-CLIENT-PRINCIPAL header. Setting this provider on a bare Windows host or non-App Service environment causes startup failures because the required EasyAuth infrastructure is absent. For local testing, simulate EasyAuth by sending the `X-MS-CLIENT-PRINCIPAL` header manually. See [Test locally with X-MS-CLIENT-PRINCIPAL](#step-4-test-locally-with-x-ms-client-principal).
 
 ## Authentication flow
 

--- a/data-api-builder/concept/security/authenticate-easy-auth.md
+++ b/data-api-builder/concept/security/authenticate-easy-auth.md
@@ -17,7 +17,7 @@ Azure App Service provides built-in authentication (often called "EasyAuth") tha
 > The `AppService` provider trusts identity headers forwarded by EasyAuth. Ensure clients can't bypass EasyAuth and reach Data API builder directly.
 
 > [!WARNING]
-> Use the `AppService` authentication provider only when hosting in Azure App Service or Azure Functions on App Service since it trusts the X-MS-CLIENT-PRINCIPAL header. Setting this provider on a bare Windows host or non-App Service environment causes startup failures because the required EasyAuth infrastructure is absent. For local testing, simulate EasyAuth by sending the `X-MS-CLIENT-PRINCIPAL` header manually. See [Test locally with X-MS-CLIENT-PRINCIPAL](#step-4-test-locally-with-x-ms-client-principal).
+> Use the `AppService` authentication provider only when hosting in Azure App Service or Azure Functions on App Service because it trusts the X-MS-CLIENT-PRINCIPAL header. Setting this provider on a bare Windows host or non-App Service environment causes startup failures because the required EasyAuth infrastructure is absent. For local testing, simulate EasyAuth by sending the `X-MS-CLIENT-PRINCIPAL` header manually. See [Test locally with X-MS-CLIENT-PRINCIPAL](#step-4-test-locally-with-x-ms-client-principal).
 
 ## Authentication flow
 


### PR DESCRIPTION
Updating the AppService authentication warning, to include the include a small clarification on the "X-MS-CLIENT-PRINCIPAL" header.